### PR TITLE
Draw empty window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.i*86
 *.x86_64
 *.hex
+typster
 
 # Debug files
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+SRC := src/merak/shade.c src/merak/screen.c src/merak/game.c \
+       src/merak/area.c src/merak/event.c src/typster.c
+INC := -I "../"
+LIB := ../sol/bld/bin/libsol.so
+
+all:
+	gcc $(INC) -Wall -Wextra -o typster $(SRC) -lSDL2 -lm $(LIB)
+

--- a/src/merak/area.c
+++ b/src/merak/area.c
@@ -1,0 +1,117 @@
+#include "merak.h"
+
+
+
+
+struct __merak_area {
+        sol_u16 width;
+        sol_u16 height;
+};
+
+
+
+
+extern sol_erno merak_area_spawn(merak_area **area,
+                                 sol_uint width,
+                                 sol_uint height)
+{
+        auto merak_area *ctx;
+
+SOL_TRY:
+        sol_assert (width <= SOL_U16_MAX && height <= SOL_U16_MAX,
+                    SOL_ERNO_RANGE);
+
+        sol_try (sol_ptr_new((sol_ptr **) area, sizeof (**area)));
+        ctx = *area;
+
+        ctx->width = width;
+        ctx->height = height;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_area_kill(merak_area **area)
+{
+        sol_ptr_free((sol_ptr **) area);
+}
+
+
+
+
+extern sol_erno merak_area_width(const merak_area *area, sol_uint *width)
+{
+SOL_TRY:
+        sol_assert (area && width, SOL_ERNO_PTR);
+
+        *width = area->width;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_area_height(const merak_area *area, sol_uint *height)
+{
+SOL_TRY:
+        sol_assert (area && height, SOL_ERNO_PTR);
+
+        *height = area->height;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_area_setwidth(merak_area *area, sol_uint width)
+{
+SOL_TRY:
+        sol_assert (area, SOL_ERNO_PTR);
+        sol_assert (width <= SOL_U16_MAX, SOL_ERNO_RANGE);
+
+        area->width = width;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_area_setheight(merak_area *area, sol_uint height)
+{
+SOL_TRY:
+        sol_assert (area, SOL_ERNO_PTR);
+        sol_assert (height <= SOL_U16_MAX, SOL_ERNO_RANGE);
+
+        area->height = height;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+

--- a/src/merak/event.c
+++ b/src/merak/event.c
@@ -1,0 +1,46 @@
+#include <SDL2/SDL.h>
+#include "merak.h"
+
+
+
+
+extern sol_erno merak_event_init(void)
+{
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+extern void merak_event_exit(void)
+{
+}
+
+
+
+
+extern sol_erno merak_event_poll(MERAK_EVENT_CODE *code)
+{
+        auto SDL_Event event;
+        auto sol_int more;
+
+        more = SDL_PollEvent(&event);
+
+        if (sol_likely (more)) {
+                switch (event.type) {
+                case SDL_QUIT:
+                        *code = MERAK_EVENT_CODE_QUIT;
+                        break;
+
+                default:
+                        *code = MERAK_EVENT_CODE_IGNORED;
+                        break;
+                }
+        }
+        else {
+                *code = MERAK_EVENT_CODE_NULL;
+        }
+
+        return SOL_ERNO_NULL;
+}
+

--- a/src/merak/game.c
+++ b/src/merak/game.c
@@ -1,0 +1,78 @@
+#include <SDL2/SDL.h>
+#include <stdlib.h>
+#include "merak.h"
+
+
+
+
+struct game {
+        merak_game_delegate *input;
+        merak_game_delegate *update;
+        merak_game_delegate *render;
+};
+
+
+
+
+static sol_tls struct game *game_inst = SOL_PTR_NULL;
+
+
+
+
+extern sol_erno merak_game_init(merak_game_delegate *input,
+                                merak_game_delegate *update,
+                                merak_game_delegate *render)
+{
+SOL_TRY:
+        sol_assert (input && update && render, SOL_ERNO_PTR);
+        sol_assert (!game_inst, SOL_ERNO_STATE);
+
+        sol_try (sol_ptr_new((sol_ptr **) &game_inst, sizeof (*game_inst)));
+        game_inst->input = input;
+        game_inst->update = update;
+        game_inst->render = render;
+
+        sol_assert (SDL_Init(SDL_INIT_EVERYTHING) >= 0, SOL_ERNO_STATE);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+        sol_log_trace("Querying SDL for errors...");
+        sol_log_error(SDL_GetError());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_game_exit(void)
+{
+        if (sol_likely (game_inst)) {
+                sol_ptr_free((sol_ptr **) &game_inst);
+                SDL_Quit();
+                exit(SOL_ERNO_NULL);
+        }
+}
+
+
+
+
+extern sol_erno merak_game_run(void)
+{
+SOL_TRY:
+        sol_assert (game_inst, SOL_ERNO_STATE);
+
+        while (SOL_BOOL_TRUE) {
+                sol_try (game_inst->input());
+                sol_try (game_inst->update());
+                sol_try (game_inst->render());
+        }
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/merak/merak.h
+++ b/src/merak/merak.h
@@ -1,0 +1,155 @@
+#if (!defined __MERAK_SCREEN)
+#define __MERAK_SCREEN
+
+
+
+
+#include "sol/inc/env.h"
+#include "sol/inc/error.h"
+#include "sol/inc/hint.h"
+#include "sol/inc/libc.h"
+#include "sol/inc/log.h"
+#include "sol/inc/prim.h"
+#include "sol/inc/ptr.h"
+#include "sol/inc/test.h"
+
+
+
+
+/*
+ * Interface: shade
+ *
+ * Description:
+ *      merak_shade represents an ARGB colour (= opacity + hue)
+ *
+ *      merak_shade_spawn() creates a new shade.
+ *      merak_shade_kill() destroys an existing shade.
+ *      merak_shade_alpha() gets alpha channel
+ *      merak_shade_red() gets red channel
+ *      merak_shade_green() gets green channel
+ *      merak_shade_blue() gets blue channel
+ *      merak_shade_setalpha() sets alpha channel
+ *      merak_shade_setred() sets red channel
+ *      merak_shade_setgreen() sets green channel
+ *      merak_shade_setblue() sets blue channel
+ */
+
+typedef struct __merak_shade merak_shade;
+
+extern sol_erno merak_shade_spawn(merak_shade **shade,
+                                  sol_word alpha,
+                                  sol_word red,
+                                  sol_word green,
+                                  sol_word blue);
+
+extern void merak_shade_kill(merak_shade **shade);
+
+extern sol_erno merak_shade_alpha(const merak_shade *shade, sol_word *alpha);
+
+extern sol_erno merak_shade_red(const merak_shade *shade, sol_word *red);
+
+extern sol_erno merak_shade_green(const merak_shade *shade, sol_word *green);
+
+extern sol_erno merak_shade_blue(const merak_shade *shade, sol_word *blue);
+
+extern sol_erno merak_shade_setalpha(merak_shade *shade, sol_word alpha);
+
+extern sol_erno merak_shade_setred(merak_shade *shade, sol_word red);
+
+extern sol_erno merak_shade_setgreen(merak_shade *shade, sol_word green);
+
+extern sol_erno merak_shade_setblue(merak_shade *shade, sol_word blue);
+
+
+
+
+/*
+ * Interface: area
+ */
+
+typedef struct __merak_area merak_area;
+
+extern sol_erno merak_area_spawn(merak_area **area,
+                                 sol_uint width,
+                                 sol_uint height);
+
+extern void merak_area_kill(merak_area **area);
+
+extern sol_erno merak_area_width(const merak_area *area, sol_uint *width);
+
+extern sol_erno merak_area_height(const merak_area *area, sol_uint *height);
+
+extern sol_erno merak_area_setwidth(merak_area *area, sol_uint width);
+
+extern sol_erno merak_area_setheight(merak_area *area, sol_uint height);
+
+
+
+
+/*
+ * Interface: screen
+ *
+ * Synopsis:
+ *      #include "merak/merak.h"
+ *
+ *      void merak_screen_init(void);
+ *      void merak_screen_exit(void);
+ *      void merak_screen_clear(const merak_shade *shade);
+ *      void merak_screen_render(void);
+ *
+ * Description:
+ *      merak_screen_init() initialises the screen manager singleton.
+ *      merak_screen_exit() destroys the screen manager.
+ *      merak_screen_clear() clears the screen.
+ *      merak_screen_render() renders the screen
+ */
+
+extern sol_erno merak_screen_init(const char *title,
+                                  const merak_area *res,
+                                  SOL_BOOL full);
+
+extern void merak_screen_exit(void);
+
+extern sol_erno merak_screen_clear(const merak_shade *shade);
+
+extern sol_erno merak_screen_render(void);
+
+
+
+
+/*
+ * Interface: game
+ */
+typedef sol_erno (merak_game_delegate)(void);
+
+extern sol_erno merak_game_init(merak_game_delegate *input,
+                                merak_game_delegate *update,
+                                merak_game_delegate *render);
+
+extern void merak_game_exit(void);
+
+extern sol_erno merak_game_run(void);
+
+
+
+
+/*
+ * Interface: event
+ */
+typedef enum MERAK_EVENT_CODE {
+        MERAK_EVENT_CODE_IGNORED = -1,
+        MERAK_EVENT_CODE_NULL = 0,
+        MERAK_EVENT_CODE_QUIT
+} MERAK_EVENT_CODE;
+
+extern sol_erno merak_event_init(void);
+
+extern void merak_event_exit(void);
+
+extern sol_erno merak_event_poll(MERAK_EVENT_CODE *code);
+
+
+
+
+#endif /* __MERAK_SCREEN */
+

--- a/src/merak/screen.c
+++ b/src/merak/screen.c
@@ -1,0 +1,119 @@
+#include <SDL2/SDL.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "merak.h"
+
+
+
+
+struct screen {
+        SDL_Renderer *renderer;
+        SDL_Window *window;
+};
+
+
+
+
+static sol_tls struct screen *screen_inst = SOL_PTR_NULL;
+
+
+
+
+extern sol_erno merak_screen_init(const char *title,
+                                  const merak_area *res,
+                                  SOL_BOOL full)
+{
+        const int wflag = full ? SDL_WINDOW_FULLSCREEN : 0;
+        auto sol_uint width, height;
+
+SOL_TRY:
+        sol_assert (title && *title, SOL_ERNO_STR);
+        sol_assert (res, SOL_ERNO_PTR);
+        sol_assert (!screen_inst, SOL_ERNO_STATE);
+
+        sol_try (sol_ptr_new((sol_ptr **) &screen_inst, sizeof (*screen_inst)));
+
+        sol_try (merak_area_width(res, &width));
+        sol_try (merak_area_height(res, &height));
+        screen_inst->window = SDL_CreateWindow(title,
+                                               SDL_WINDOWPOS_CENTERED,
+                                               SDL_WINDOWPOS_CENTERED,
+                                               width,
+                                               height,
+                                               wflag);
+        sol_assert (screen_inst->window, SOL_ERNO_STATE);
+
+        SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+        screen_inst->renderer = SDL_CreateRenderer(screen_inst->window,
+                                                   -1,
+                                                   SDL_RENDERER_ACCELERATED);
+        sol_assert (screen_inst->renderer, SOL_ERNO_STATE);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+        sol_log_trace("Querying SDL for errors...");
+        sol_log_error(SDL_GetError());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_screen_exit(void)
+{
+        if (sol_likely (screen_inst)) {
+                SDL_DestroyRenderer(screen_inst->renderer);
+                SDL_DestroyWindow(screen_inst->window);
+
+                sol_ptr_free((sol_ptr **) &screen_inst);
+        }
+}
+
+
+
+
+extern sol_erno merak_screen_clear(const merak_shade *shade)
+{
+        auto sol_word alpha, red, green, blue;
+
+SOL_TRY:
+        sol_assert (shade, SOL_ERNO_PTR);
+        sol_assert (screen_inst, SOL_ERNO_STATE);
+
+        sol_try (merak_shade_alpha(shade, &alpha));
+        sol_try (merak_shade_red(shade, &red));
+        sol_try (merak_shade_green(shade, &green));
+        sol_try (merak_shade_blue(shade, &blue));
+
+        SDL_SetRenderDrawColor(screen_inst->renderer, alpha, red, green, blue);
+        SDL_RenderClear(screen_inst->renderer);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+        sol_log_trace("Querying SDL for errors...");
+        sol_log_error(SDL_GetError());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_screen_render(void)
+{
+SOL_TRY:
+        sol_assert (screen_inst, SOL_ERNO_STATE);
+        SDL_RenderPresent(screen_inst->renderer);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+        sol_log_trace("Querying SDL for errors...");
+        sol_log_error(SDL_GetError());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/merak/shade.c
+++ b/src/merak/shade.c
@@ -1,0 +1,183 @@
+#include "merak.h"
+
+
+
+
+struct __merak_shade {
+        sol_w8 alpha;
+        sol_w8 red;
+        sol_w8 green;
+        sol_w8 blue;
+};
+
+
+
+
+extern sol_word merak_shade_spawn(merak_shade **shade,
+                                  sol_word alpha,
+                                  sol_word red,
+                                  sol_word green,
+                                  sol_word blue)
+{
+        auto merak_shade *ctx;
+
+SOL_TRY:
+        sol_try (sol_ptr_new((sol_ptr **) shade, sizeof (**shade)));
+        ctx = *shade;
+
+        sol_try (merak_shade_setalpha(ctx, alpha));
+        sol_try (merak_shade_setred(ctx, red));
+        sol_try (merak_shade_setgreen(ctx, green));
+        sol_try (merak_shade_setblue(ctx, blue));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_shade_kill(merak_shade **shade)
+{
+        sol_ptr_free((sol_ptr **) shade);
+}
+
+
+
+
+extern sol_erno merak_shade_alpha(const merak_shade *shade, sol_word *alpha)
+{
+SOL_TRY:
+        sol_assert (shade && alpha, SOL_ERNO_PTR);
+
+        *alpha = (sol_word) shade->alpha;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_red(const merak_shade *shade, sol_word *red)
+{
+SOL_TRY:
+        sol_assert (shade && red, SOL_ERNO_PTR);
+
+        *red = (sol_word) shade->red;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_green(const merak_shade *shade, sol_word *green)
+{
+SOL_TRY:
+        sol_assert (shade && green, SOL_ERNO_PTR);
+
+        *green = (sol_word) shade->green;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_blue(const merak_shade *shade, sol_word *blue)
+{
+SOL_TRY:
+        sol_assert (shade && blue, SOL_ERNO_PTR);
+
+        *blue = (sol_word) shade->blue;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_setalpha(merak_shade *shade, sol_word alpha)
+{
+SOL_TRY:
+        sol_assert (shade, SOL_ERNO_PTR);
+
+        shade->alpha = (sol_w8) alpha;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_setred(merak_shade *shade, sol_word red)
+{
+SOL_TRY:
+        sol_assert (shade, SOL_ERNO_PTR);
+
+        shade->red = (sol_w8) red;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_setgreen(merak_shade *shade, sol_word green)
+{
+SOL_TRY:
+        sol_assert (shade, SOL_ERNO_PTR);
+
+        shade->green = (sol_w8) green;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_shade_setblue(merak_shade *shade, sol_word blue)
+{
+SOL_TRY:
+        sol_assert (shade, SOL_ERNO_PTR);
+
+        shade->blue = (sol_w8) blue;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/typster.c
+++ b/src/typster.c
@@ -1,0 +1,105 @@
+#include "merak/merak.h"
+
+
+
+
+        /* handles the input for a frame */
+sol_erno frame_input(void)
+{
+        auto MERAK_EVENT_CODE code;
+
+SOL_TRY:
+        sol_try (merak_event_poll(&code));
+
+        while (code) {
+                switch (code) {
+                case MERAK_EVENT_CODE_QUIT:
+                        merak_screen_exit();
+                        merak_event_exit();
+                        merak_game_exit();
+                        break;
+
+                default:
+                        break;
+                }
+
+                sol_try (merak_event_poll(&code));
+        }
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+
+}
+
+
+
+
+        /* updates the state of a frame */
+sol_erno frame_update(void)
+{
+        auto merak_shade *shade = SOL_PTR_NULL;
+
+SOL_TRY:
+        sol_try (merak_shade_spawn(&shade, 96, 128, 128, 256));
+        sol_try (merak_screen_clear(shade));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        merak_shade_kill(&shade);
+        return sol_erno_get();
+}
+
+
+
+
+        /* renders a frame */
+sol_erno frame_render(void)
+{
+SOL_TRY:
+        sol_try (merak_screen_render());
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+int main(int argc, char *argv[])
+{
+        auto merak_area *res = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* cast arguments to void as we don't use them */
+        (void) argc;
+        (void) argv;
+
+        sol_try (merak_area_spawn(&res, 1280, 720));
+
+        sol_try (merak_game_init(&frame_input, &frame_update, &frame_render));
+        sol_try (merak_screen_init("Typster", res, SOL_BOOL_TRUE));
+        sol_try (merak_event_init());
+
+        sol_try (merak_game_run());
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        merak_area_kill(&res);
+
+        merak_screen_exit();
+        merak_event_exit();
+        merak_game_exit();
+
+        return (int) sol_erno_get();
+}
+


### PR DESCRIPTION
Typster now successfully draws a blank fullscreen window using the SDL
library. The game logic has been separated from the game management by
introducing the Merak subsystem, which will probably develop into a
separate library of its own.

The Merak subsystem now comprises of distinct game, screen, and event
managers. These managers do the heavy-lifting, allowing Typster to focus
on the game logic.

The Sol Library has also been incorporated in order to improve and
simplify the Merak and Typster source code.

This pull request closes #4.