### PR TITLE
Create game entity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SRC := src/merak/screen.c src/merak/game.c \
-       src/merak/event.c \
+SRC := src/merak/screen.c src/merak/game.c src/merak/entity.c \
+       src/merak/event.c src/enemy.c src/merak/vector.c \
        src/merak/texture.c src/merak/sprite.c src/typster.c
 INC := -I "../"
 LIB := ../sol/bld/bin/libsol.so

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -1,0 +1,49 @@
+#include <SDL2/SDL.h>
+#include "typster.h"
+
+
+
+
+static sol_erno delegate_update(merak_entity *enemy)
+{
+        const sol_index row = 1;
+        const sol_index col = ((SDL_GetTicks() / 100) % 4) + 1;
+
+SOL_TRY:
+        sol_try(merak_entity_setframe(enemy, row, col));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno typster_enemy_new(typster_enemy **enemy)
+{
+        auto merak_sprite *sprite = SOL_PTR_NULL;
+
+SOL_TRY:
+        sol_try (merak_sprite_new(&sprite, "res/typster.png", 1, 4));
+        sol_try (merak_entity_new((merak_entity **) enemy,
+                                  sprite,
+                                  &delegate_update));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void typster_enemy_free(typster_enemy **enemy)
+{
+        merak_entity_free((merak_entity **) enemy);
+}
+

--- a/src/merak/entity.c
+++ b/src/merak/entity.c
@@ -1,0 +1,306 @@
+#include "merak.h"
+#include <math.h>
+
+
+
+
+struct __merak_entity {
+        merak_vector *vec;
+        merak_sprite *sprite;
+        merak_entity_delegate *update;
+        merak_entity_delegate *dispose;
+        merak_entity_delegate *draw;
+        sol_size nref;
+};
+
+
+
+
+/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+static sol_inline SOL_BOOL float_lt(sol_float lhs, sol_float rhs)
+{
+        const sol_float epsilon = (sol_float) 0.000001;
+
+        return (rhs - lhs) > ((fabs(lhs) < fabs(rhs)
+                              ? fabs(rhs)
+                              : fabs(lhs)) * epsilon)
+               ? SOL_BOOL_TRUE
+               : SOL_BOOL_FALSE;
+}
+
+
+
+
+static sol_erno draw_default(merak_entity *entity)
+{
+        const sol_float zero = (sol_float) 0.0;
+        auto sol_float x, y;
+        auto merak_point pos;
+
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_x(entity->vec, &x));
+        sol_try (merak_vector_x(entity->vec, &y));
+
+        if (sol_likely (!float_lt(x, zero) && !float_lt(y, zero))) {
+                pos.x = (sol_u16) x;
+                pos.y = (sol_u16) y;
+                sol_try (merak_sprite_draw(entity->sprite, &pos));
+        }
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+static sol_erno dispose_default(merak_entity *entity)
+{
+        (void) entity;
+        return SOL_BOOL_TRUE;
+}
+
+
+
+
+extern sol_erno merak_entity_new(merak_entity **entity,
+                                 merak_sprite *sprite,
+                                 merak_entity_delegate *update)
+{
+SOL_TRY:
+        sol_try (merak_entity_new3(entity,
+                                   sprite,
+                                   update,
+                                   &dispose_default,
+                                   &draw_default));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_new2(merak_entity **entity,
+                                  merak_sprite *sprite,
+                                  merak_entity_delegate *update,
+                                  merak_entity_delegate *dispose)
+{
+SOL_TRY:
+        sol_try (merak_entity_new3(entity,
+                                   sprite,
+                                   update,
+                                   dispose,
+                                   &draw_default));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_new3(merak_entity **entity,
+                                  merak_sprite *sprite,
+                                  merak_entity_delegate *update,
+                                  merak_entity_delegate *dispose,
+                                  merak_entity_delegate *draw)
+{
+        auto merak_entity *ctx;
+
+SOL_TRY:
+        sol_assert (sprite && update && dispose && draw, SOL_ERNO_PTR);
+
+        sol_try (sol_ptr_new((sol_ptr **) entity, sizeof (**entity)));
+        ctx = *entity;
+        ctx->nref = (sol_size) 1;
+
+        ctx->vec = SOL_PTR_NULL;
+        sol_try (merak_vector_new(&ctx->vec));
+
+        ctx->sprite = SOL_PTR_NULL;
+        sol_try (merak_sprite_copy(&ctx->sprite, sprite));
+
+        ctx->update = update;
+        ctx->dispose = dispose;
+        ctx->draw = draw;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_copy(merak_entity **lhs, merak_entity *rhs)
+{
+SOL_TRY:
+        sol_assert (lhs && rhs, SOL_ERNO_PTR);
+        sol_assert (!*lhs, SOL_ERNO_STATE);
+
+        rhs->nref++;
+        *lhs = rhs;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_entity_free(merak_entity **entity)
+{
+        auto merak_entity *hnd;
+
+        if (sol_likely (entity && (hnd = *entity))) {
+                (void) hnd->dispose(hnd);
+
+                merak_sprite_free(&hnd->sprite);
+                merak_vector_free(&hnd->vec);
+        }
+
+        sol_ptr_free((sol_ptr **) entity);
+}
+
+
+
+
+extern sol_erno merak_entity_vec(const merak_entity *entity, merak_vector **vec)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_copy(vec, entity->vec));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_frame(const merak_entity *entity,
+                                   sol_index *row,
+                                   sol_index *col)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (merak_sprite_frame(entity->sprite, row, col));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_setvec(merak_entity *entity,
+                                    const merak_vector *vec)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        merak_vector_free(&entity->vec);
+        sol_try (merak_vector_copy(&entity->vec, vec));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_setframe(merak_entity *entity,
+                                      sol_index row,
+                                      sol_index col)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (merak_sprite_setframe(entity->sprite, row, col));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_move(merak_entity *entity,
+                                  const merak_vector *velocity)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_add(entity->vec, velocity));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_update(merak_entity *entity)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (entity->update(entity));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_entity_draw(merak_entity *entity)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (entity->draw(entity));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/merak/game.c
+++ b/src/merak/game.c
@@ -6,16 +6,154 @@
 
 
 
+struct list_node {
+        merak_entity *elem;
+        struct list_node *next;
+};
+
+
+
+
+struct list {
+        struct list_node *head;
+        struct list_node *tail;
+        struct list_node *curr;
+        sol_size nelem;
+};
+
+
+
+
 struct game {
         merak_game_delegate *input;
         merak_game_delegate *update;
         merak_game_delegate *render;
+        struct list *entities;
 };
 
 
 
 
 static sol_tls struct game *game_inst = SOL_PTR_NULL;
+
+
+
+
+static sol_erno list_new(struct list **list)
+{
+        auto struct list *hnd;
+
+SOL_TRY:
+        sol_assert (list, SOL_ERNO_PTR);
+
+        sol_try (sol_ptr_new((sol_ptr **) list, sizeof (**list)));
+        hnd = *list;
+
+        hnd->head = SOL_PTR_NULL;
+        hnd->tail = SOL_PTR_NULL;
+        hnd->curr = SOL_PTR_NULL;
+        hnd->nelem = (sol_size) 0;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+static void list_free(struct list **list)
+{
+        auto struct list *hnd;
+        auto struct list_node *node;
+
+        if (sol_likely (list && (hnd = *list))) {
+                hnd->curr = hnd->head;
+
+                while ((node = hnd->curr)) {
+                        hnd->curr = hnd->curr->next;
+
+                        merak_entity_free(&node->elem);
+                        sol_ptr_free((sol_ptr **) &node);
+                }
+
+                sol_ptr_free ((sol_ptr **) list);
+        }
+}
+
+
+
+
+static sol_erno list_push(struct list *list, merak_entity *elem)
+{
+        auto struct list_node *node = SOL_PTR_NULL;
+
+SOL_TRY:
+        sol_assert (list && elem, SOL_ERNO_PTR);
+
+        sol_try (sol_ptr_new((sol_ptr **) &node, sizeof (*node)));
+
+        node->elem = SOL_PTR_NULL;
+        node->next = SOL_PTR_NULL;
+
+        sol_try (merak_entity_copy(&node->elem, elem));
+
+        if (!list->head)
+                list->head = node;
+
+        if (list->tail)
+                list->tail->next = node;
+
+        list->tail = node;
+        list->nelem++;
+
+SOL_CATCH:
+        if (node) {
+                merak_entity_free(&node->elem);
+                sol_ptr_free((sol_ptr **) &node);
+        }
+
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+static sol_erno list_start(struct list *list)
+{
+SOL_TRY:
+        sol_assert (list, SOL_ERNO_PTR);
+
+        list->curr = list->head;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+static sol_erno list_next(struct list *list)
+{
+SOL_TRY:
+        sol_assert (list, SOL_ERNO_PTR);
+
+        list->curr = list->curr->next;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
 
 
 
@@ -34,6 +172,9 @@ SOL_TRY:
         game_inst->input = input;
         game_inst->update = update;
         game_inst->render = render;
+
+        game_inst->entities = SOL_PTR_NULL;
+        sol_try (list_new(&game_inst->entities));
 
         sol_assert (SDL_Init(SDL_INIT_EVERYTHING) >= 0, SOL_ERNO_STATE);
         sol_assert ((IMG_Init(iflag) & iflag) == iflag, SOL_ERNO_STATE);
@@ -54,9 +195,12 @@ SOL_FINALLY:
 extern void merak_game_exit(void)
 {
         if (sol_likely (game_inst)) {
+                list_free(&game_inst->entities);
                 sol_ptr_free((sol_ptr **) &game_inst);
+
                 SDL_Quit();
                 IMG_Quit();
+
                 exit(SOL_ERNO_NULL);
         }
 }
@@ -64,15 +208,53 @@ extern void merak_game_exit(void)
 
 
 
+extern sol_erno merak_game_register(merak_entity *entity)
+{
+SOL_TRY:
+        sol_assert (entity, SOL_ERNO_PTR);
+        sol_assert (game_inst, SOL_ERNO_STATE);
+
+        sol_try (list_push(game_inst->entities, entity));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
 extern sol_erno merak_game_run(void)
 {
+        auto struct list_node *curr;
+
 SOL_TRY:
         sol_assert (game_inst, SOL_ERNO_STATE);
 
         while (SOL_BOOL_TRUE) {
                 sol_try (game_inst->input());
+
                 sol_try (game_inst->update());
+                sol_try (list_start(game_inst->entities));
+
+                while ((curr = game_inst->entities->curr)) {
+                        sol_try (merak_entity_update(curr->elem));
+                        sol_try (merak_entity_draw(curr->elem));
+
+                        sol_try (list_next(game_inst->entities));
+                }
+
                 sol_try (game_inst->render());
+                sol_try (list_start(game_inst->entities));
+
+                while ((curr = game_inst->entities->curr)) {
+                        sol_try (merak_entity_draw(curr->elem));
+                        sol_try (list_next(game_inst->entities));
+                }
+
+                sol_try (merak_screen_render());
         }
 
 SOL_CATCH:

--- a/src/merak/merak.h
+++ b/src/merak/merak.h
@@ -1,5 +1,5 @@
-#if (!defined __MERAK_SCREEN)
-#define __MERAK_SCREEN
+#if (!defined __MERAK_API)
+#define __MERAK_API
 
 
 
@@ -69,6 +69,65 @@ typedef struct __merak_area {
 
 
 /*
+ * Interface: vector
+ */
+
+typedef struct __merak_vector merak_vector;
+
+extern sol_erno merak_vector_new(merak_vector **vec);
+
+extern sol_erno merak_vector_new2(merak_vector **vec,
+                                  const sol_float x,
+                                  const sol_float y);
+
+extern sol_erno merak_vector_copy(merak_vector **lhs, const merak_vector *rhs);
+
+extern void merak_vector_free(merak_vector **vec);
+
+extern sol_erno merak_vector_x(const merak_vector *vec, sol_float *x);
+
+extern sol_erno merak_vector_y(const merak_vector *vec, sol_float *y);
+
+extern sol_erno merak_vector_len(const merak_vector *vec, sol_float *len);
+
+extern sol_erno merak_vector_setx(merak_vector *vec, const sol_float x);
+
+extern sol_erno merak_vector_sety(merak_vector *vec, const sol_float y);
+
+extern sol_erno merak_vector_lt(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *lt);
+
+extern sol_erno merak_vector_eq(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *eq);
+
+extern sol_erno merak_vector_gt(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *gt);
+
+extern sol_erno merak_vector_add(merak_vector *lhs, const merak_vector *rhs);
+
+extern sol_erno merak_vector_add2(merak_vector *vec,
+                                  const sol_float x,
+                                  const sol_float y);
+
+extern sol_erno merak_vector_sub(merak_vector *lhs, const merak_vector *rhs);
+
+extern sol_erno merak_vector_sub2(merak_vector *vec,
+                                  const sol_float x,
+                                  const sol_float y);
+
+extern sol_erno merak_vector_mul(merak_vector *vec, const sol_float scalar);
+
+extern sol_erno merak_vector_div(merak_vector *vec, const sol_float scalar);
+
+extern sol_erno merak_vector_norm(merak_vector *vec);
+
+
+
+
+/*
  * Interface: screen
  *
  * Synopsis:
@@ -102,22 +161,6 @@ extern sol_erno merak_screen_render(void);
 
 
 /*
- * Interface: game
- */
-typedef sol_erno (merak_game_delegate)(void);
-
-extern sol_erno merak_game_init(merak_game_delegate *input,
-                                merak_game_delegate *update,
-                                merak_game_delegate *render);
-
-extern void merak_game_exit(void);
-
-extern sol_erno merak_game_run(void);
-
-
-
-
-/*
  * Interface: event
  */
 typedef enum __MERAK_EVENT_CODE {
@@ -145,6 +188,8 @@ typedef struct __merak_sprite merak_sprite;
 
 extern sol_erno merak_texture_new(merak_texture **tex, const char *fpath);
 
+extern sol_erno merak_texture_copy(merak_texture **lhs, merak_texture *rhs);
+
 extern void merak_texture_free(merak_texture **tex);
 
 extern sol_erno merak_texture_area(const merak_texture *tex, merak_area *area);
@@ -162,6 +207,9 @@ extern sol_erno merak_sprite_new(merak_sprite **sprite,
                                  sol_size nrow,
                                  sol_size ncol);
 
+extern sol_erno merak_sprite_copy(merak_sprite **lhs, merak_sprite *rhs);
+
+
 extern void merak_sprite_free(merak_sprite **sprite);
 
 extern sol_erno merak_sprite_area(const merak_sprite *sprite,
@@ -170,13 +218,88 @@ extern sol_erno merak_sprite_area(const merak_sprite *sprite,
 extern sol_erno merak_sprite_nframe(const merak_sprite *sprite,
                                     sol_size *nframe);
 
+extern sol_erno merak_sprite_frame(const merak_sprite *sprite,
+                                   sol_index *row,
+                                   sol_index *col);
+
+extern sol_erno merak_sprite_setframe(merak_sprite *sprite,
+                                      sol_index row,
+                                      sol_index col);
+
 extern sol_erno merak_sprite_draw(const merak_sprite *sprite,
-                                  sol_index row,
-                                  sol_index col,
-                                  const merak_point *loc);
+                                  const merak_point *pos);
 
 
 
 
-#endif /* __MERAK_SCREEN */
+/*
+ * Interface: entity
+ */
+
+typedef struct __merak_entity merak_entity;
+
+typedef sol_erno (merak_entity_delegate)(merak_entity *entity);
+
+extern sol_erno merak_entity_new(merak_entity **entity,
+                                 merak_sprite *sprite,
+                                 merak_entity_delegate *update);
+
+extern sol_erno merak_entity_new2(merak_entity **entity,
+                                  merak_sprite *sprite,
+                                  merak_entity_delegate *update,
+                                  merak_entity_delegate *dispose);
+
+extern sol_erno merak_entity_new3(merak_entity **entity,
+                                  merak_sprite *sprite,
+                                  merak_entity_delegate *update,
+                                  merak_entity_delegate *dispose,
+                                  merak_entity_delegate *draw);
+
+extern sol_erno merak_entity_copy(merak_entity **lhs, merak_entity *rhs);
+
+extern void merak_entity_free(merak_entity **entity);
+
+extern sol_erno merak_entity_vec(const merak_entity *entity,
+                                 merak_vector **vec);
+
+extern sol_erno merak_entity_frame(const merak_entity *entity,
+                                   sol_index *row,
+                                   sol_index *col);
+
+extern sol_erno merak_entity_setvec(merak_entity *entity,
+                                    const merak_vector *vec);
+
+extern sol_erno merak_entity_setframe(merak_entity *entity,
+                                      sol_index row,
+                                      sol_index col);
+
+extern sol_erno merak_entity_move(merak_entity *entity,
+                                  const merak_vector *velocity);
+
+extern sol_erno merak_entity_update(merak_entity *entity);
+
+extern sol_erno merak_entity_draw(merak_entity *entity);
+
+
+
+
+/*
+ * Interface: game
+ */
+typedef sol_erno (merak_game_delegate)(void);
+
+extern sol_erno merak_game_init(merak_game_delegate *input,
+                                merak_game_delegate *update,
+                                merak_game_delegate *render);
+
+extern void merak_game_exit(void);
+
+extern sol_erno merak_game_register(merak_entity *entity);
+
+extern sol_erno merak_game_run(void);
+
+
+
+
+#endif /* __MERAK_API */
 

--- a/src/merak/screen.c
+++ b/src/merak/screen.c
@@ -22,7 +22,6 @@ extern sol_erno merak_screen_init(const char *title,
                                   SOL_BOOL full)
 {
         const int wflag = full ? SDL_WINDOW_FULLSCREEN : 0;
-        //auto sol_uint width, height;
 
 SOL_TRY:
         sol_assert (title && *title, SOL_ERNO_STR);
@@ -31,8 +30,6 @@ SOL_TRY:
 
         sol_try (sol_ptr_new((sol_ptr **) &screen_inst, sizeof (*screen_inst)));
 
-        //sol_try (merak_area_width(res, &width));
-        //sol_try (merak_area_height(res, &height));
         screen_inst->window = SDL_CreateWindow(title,
                                                SDL_WINDOWPOS_CENTERED,
                                                SDL_WINDOWPOS_CENTERED,

--- a/src/merak/sprite.c
+++ b/src/merak/sprite.c
@@ -9,6 +9,9 @@ struct __merak_sprite {
         merak_texture *tex;
         sol_u8 nrow;
         sol_u8 ncol;
+        sol_u8 row;
+        sol_u8 col;
+        sol_size nref;
 };
 
 
@@ -23,13 +26,19 @@ extern sol_erno merak_sprite_new(merak_sprite **sprite,
 
 SOL_TRY:
         sol_assert (nrow && ncol, SOL_ERNO_RANGE);
-        sol_assert (nrow <= SOL_U8_MAX && ncol <= SOL_U8_MAX, SOL_ERNO_RANGE);
+        sol_assert (nrow >= 1
+                    && nrow <= SOL_U8_MAX
+                    && ncol >= 1
+                    && ncol <= SOL_U8_MAX,
+                    SOL_ERNO_RANGE);
 
         sol_try (sol_ptr_new((sol_ptr **) sprite, sizeof (**sprite)));
         ctx = *sprite;
+        ctx->nref = (sol_size) 1;
 
         ctx->nrow = nrow;
         ctx->ncol = ncol;
+        ctx->row = ctx->col = 1;
 
         ctx->tex = SOL_PTR_NULL;
         sol_try(merak_texture_new(&ctx->tex, fpath));
@@ -44,12 +53,35 @@ SOL_FINALLY:
 
 
 
+extern sol_erno merak_sprite_copy(merak_sprite **lhs, merak_sprite *rhs)
+{
+SOL_TRY:
+        sol_assert (lhs && rhs, SOL_ERNO_PTR);
+        sol_assert (!*lhs, SOL_ERNO_STATE);
+
+        rhs->nref++;
+        *lhs = rhs;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
 extern void merak_sprite_free(merak_sprite **sprite)
 {
-        if (sol_likely (sprite && *sprite))
-                merak_texture_free(&(*sprite)->tex);
+        auto merak_sprite *hnd;
 
-        sol_ptr_free((sol_ptr **) sprite);
+        if (sol_likely (sprite && (hnd = *sprite))) {
+                if (!(--hnd->nref)) {
+                        merak_texture_free(&hnd->tex);
+                        sol_ptr_free((sol_ptr **) sprite);
+                }
+        }
 }
 
 
@@ -92,25 +124,67 @@ SOL_FINALLY:
 
 
 
+extern sol_erno merak_sprite_frame(const merak_sprite *sprite,
+                                   sol_index *row,
+                                   sol_index *col)
+{
+SOL_TRY:
+        sol_assert (sprite && row && col, SOL_ERNO_PTR);
+
+        *row = sprite->row;
+        *col = sprite->col;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_sprite_setframe(merak_sprite *sprite,
+                                      sol_index row,
+                                      sol_index col)
+{
+SOL_TRY:
+        sol_assert (sprite, SOL_ERNO_PTR);
+        sol_assert (row >= 1
+                    && row <= sprite->nrow
+                    && col >= 1
+                    && col <= sprite->ncol,
+                    SOL_ERNO_RANGE);
+
+        sprite->row = row;
+        sprite->col = col;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
 extern sol_erno merak_sprite_draw(const merak_sprite *sprite,
-                                  sol_index row,
-                                  sol_index col,
-                                  const merak_point *dst)
+                                  const merak_point *pos)
 {
         auto merak_area area, clip;
         auto merak_point src;
 
 SOL_TRY:
         sol_assert (sprite, SOL_ERNO_PTR);
-        sol_assert (row <= sprite->nrow && col <= sprite->ncol, SOL_ERNO_RANGE);
 
         sol_try (merak_texture_area(sprite->tex, &area));
         clip.width = area.width / sprite->ncol;
         clip.height = area.height / sprite->nrow;
 
-        src.x = clip.width * (col - 1);
-        src.y = clip.height * (row - 1);
-        sol_try (merak_texture_draw(sprite->tex, &src, &clip, dst));
+        src.x = clip.width * (sprite->col - 1);
+        src.y = clip.height * (sprite->row - 1);
+        sol_try (merak_texture_draw(sprite->tex, &src, &clip, pos));
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());

--- a/src/merak/vector.c
+++ b/src/merak/vector.c
@@ -1,0 +1,413 @@
+#include "merak.h"
+#include <math.h>
+
+
+
+
+struct __merak_vector {
+        sol_f32 x;
+        sol_f32 y;
+};
+
+
+
+
+#define FLOAT_EPSILON (0.000001f)
+
+
+
+
+/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+static sol_inline SOL_BOOL float_lt(sol_float lhs, sol_float rhs)
+{
+        return (rhs - lhs) > ((fabs(lhs) < fabs(rhs)
+                              ? fabs(rhs)
+                              : fabs(lhs)) * FLOAT_EPSILON)
+               ? SOL_BOOL_TRUE
+               : SOL_BOOL_FALSE;
+}
+
+
+
+
+/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+static sol_inline SOL_BOOL float_eq(sol_float lhs, sol_float rhs)
+{
+        return fabs(lhs - rhs) <= ((fabs(lhs) > fabs(rhs)
+                                   ? fabs(rhs)
+                                   : fabs(lhs)) * FLOAT_EPSILON)
+               ? SOL_BOOL_TRUE
+               : SOL_BOOL_FALSE;
+}
+
+
+
+
+/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+static SOL_BOOL float_gt(sol_float lhs, sol_float rhs)
+{
+        return (lhs - rhs) > ((fabs(lhs) < fabs(rhs)
+                              ? fabs(rhs)
+                              : fabs(lhs)) * FLOAT_EPSILON)
+               ? SOL_BOOL_TRUE
+               : SOL_BOOL_FALSE;
+}
+
+
+
+
+extern sol_erno merak_vector_new(merak_vector **vec)
+{
+        const sol_float def = (sol_float) 0.0;
+
+SOL_TRY:
+        sol_try (merak_vector_new2(vec, def, def));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_new2(merak_vector **vec,
+                                  const sol_float x,
+                                  const sol_float y)
+{
+        auto merak_vector *hnd;
+
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        sol_try (sol_ptr_new((sol_ptr **) vec, sizeof (**vec)));
+        hnd = *vec;
+
+        hnd->x = (sol_f32) x;
+        hnd->y = (sol_f32) y;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_copy(merak_vector **lhs, const merak_vector *rhs)
+{
+SOL_TRY:
+        sol_assert (rhs, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_new2(lhs,
+                                   (sol_float) rhs->x,
+                                   (sol_float) rhs->y));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_vector_free(merak_vector **vec)
+{
+        sol_ptr_free((sol_ptr **) vec);
+}
+
+
+
+
+extern sol_erno merak_vector_x(const merak_vector *vec, sol_float *x)
+{
+SOL_TRY:
+        sol_assert (vec && x, SOL_ERNO_PTR);
+
+        *x = (sol_float) vec->x;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_y(const merak_vector *vec, sol_float *y)
+{
+SOL_TRY:
+        sol_assert (vec && y, SOL_ERNO_PTR);
+
+        *y = (sol_float) vec->y;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_len(const merak_vector *vec, sol_float *len)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        *len = (sol_float) sqrt((double) (vec->x * vec->x)
+                                + (double) (vec->y * vec->y));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_setx(merak_vector *vec, const sol_float x)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        vec->x = (sol_f32) x;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_sety(merak_vector *vec, const sol_float y)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        vec->y = (sol_f32) y;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_lt(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *lt)
+{
+        auto sol_float llen, rlen;
+
+SOL_TRY:
+        sol_assert (lt, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_len(lhs, &llen));
+        sol_try (merak_vector_len(rhs, &rlen));
+        *lt = float_lt(llen, rlen);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_eq(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *eq)
+{
+        auto sol_float llen, rlen;
+
+SOL_TRY:
+        sol_assert (eq, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_len(lhs, &llen));
+        sol_try (merak_vector_len(rhs, &rlen));
+        *eq = float_eq(llen, rlen);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_gt(const merak_vector *lhs,
+                                const merak_vector *rhs,
+                                SOL_BOOL *gt)
+{
+        auto sol_float llen, rlen;
+
+SOL_TRY:
+        sol_assert (gt, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_len(lhs, &llen));
+        sol_try (merak_vector_len(rhs, &rlen));
+        *gt = float_gt(llen, rlen);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_add(merak_vector *lhs, const merak_vector *rhs)
+{
+SOL_TRY:
+        sol_assert (rhs, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_add2(lhs,
+                                   (sol_float) rhs->x,
+                                   (sol_float) rhs->y));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_add2(merak_vector *vec,
+                                  const sol_float x,
+                                  const sol_float y)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        vec->x += (sol_f32) x;
+        vec->y += (sol_f32) y;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_sub(merak_vector *lhs, const merak_vector *rhs)
+{
+SOL_TRY:
+        sol_assert (rhs, SOL_ERNO_PTR);
+
+        sol_try (merak_vector_sub2(lhs,
+                                   (sol_float) rhs->x,
+                                   (sol_float) rhs->y));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_sub2(merak_vector *vec,
+                                  const sol_float x,
+                                  const sol_float y)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        vec->x -= (sol_f32) x;
+        vec->y -= (sol_f32) y;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_mul(merak_vector *vec, const sol_float scalar)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+
+        vec->x *= (sol_f32) scalar;
+        vec->y *= (sol_f32) scalar;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+extern sol_erno merak_vector_div(merak_vector *vec, const sol_float scalar)
+{
+SOL_TRY:
+        sol_assert (vec, SOL_ERNO_PTR);
+        sol_assert (!float_eq(scalar, (sol_float) 0.0), SOL_ERNO_RANGE);
+
+        vec->x /= (sol_f32) scalar;
+        vec->y /= (sol_f32) scalar;
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_vector_norm(merak_vector *vec)
+{
+        auto sol_float len;
+
+SOL_TRY:
+        sol_try (merak_vector_len(vec, &len));
+
+        if (sol_likely (!float_eq(len, (sol_float) 0.0)))
+                sol_try (merak_vector_mul(vec, (1.0 / len)));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/typster.c
+++ b/src/typster.c
@@ -1,4 +1,11 @@
+#include <SDL2/SDL.h>
 #include "merak/merak.h"
+#include "typster.h"
+
+
+
+
+static typster_enemy *enemy = SOL_PTR_NULL;
 
 
 
@@ -40,9 +47,6 @@ SOL_FINALLY:
         /* updates the state of a frame */
 sol_erno frame_update(void)
 {
-        auto merak_texture *dragon = SOL_PTR_NULL;
-        auto merak_sprite *typster = SOL_PTR_NULL;
-        auto merak_point loc;
         auto merak_shade shade;
 
 SOL_TRY:
@@ -52,23 +56,10 @@ SOL_TRY:
         shade.alpha = 96;
         sol_try (merak_screen_clear(&shade));
 
-        sol_try (merak_texture_new(&dragon, "res/typster.png"));
-        loc.x = 100;
-        loc.y = 150;
-        sol_try (merak_texture_render(dragon, &loc));
-
-        sol_try (merak_sprite_new(&typster, "res/typster.png", 1, 4));
-        loc.x = loc.y = 400;
-        sol_try (merak_sprite_draw(typster, 1, 3, &loc));
-
-
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
 
 SOL_FINALLY:
-        merak_texture_free(&dragon);
-        merak_sprite_free(&typster);
-
         return sol_erno_get();
 }
 
@@ -79,7 +70,7 @@ SOL_FINALLY:
 sol_erno frame_render(void)
 {
 SOL_TRY:
-        sol_try (merak_screen_render());
+        sol_assert (SOL_BOOL_TRUE, SOL_ERNO_STATE);
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
@@ -108,18 +99,22 @@ SOL_TRY:
         sol_try (merak_screen_init("Typster", &res, SOL_BOOL_TRUE));
         sol_try (merak_event_init());
 
+        sol_try (typster_enemy_new(&enemy));
+        sol_try (merak_game_register((merak_entity *) enemy));
+
         sol_try (merak_game_run());
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
 
 SOL_FINALLY:
-        sol_log_close();
+        typster_enemy_free(&enemy);
 
         merak_screen_exit();
         merak_event_exit();
         merak_game_exit();
 
+        sol_log_close();
         return (int) sol_erno_get();
 }
 

--- a/src/typster.h
+++ b/src/typster.h
@@ -1,0 +1,24 @@
+#if (!defined __TYPSTER_API)
+#define __TYPSTER_API
+
+
+
+
+#include "merak/merak.h"
+
+
+
+
+/*
+ * Interface: enemy
+ */
+
+//typedef merak_entity typster_enemy;
+typedef struct __typster_enemy typster_enemy;
+
+extern sol_erno typster_enemy_new(typster_enemy **enemy);
+
+extern void typster_enemy_free(typster_enemy **enemy);
+
+#endif // __TYPSTER_API
+


### PR DESCRIPTION
The entity type has been created as an opaque type with the following
interface functions:
  * `merak_entity_new()`
  * `merak_entity_new2()`
  * `merak_entity_new3()`
  * `merak_entity_copy()`
  * `merak_entity_free()`
  * `merak_entity_vec()`
  * `merak_entity_frame()`
  * `merak_entity_setframe()`
  * `merak_entity_setvec()`
  * `merak_entity_move()`
  * `merak_entity_update()`
  * `merak_entity_draw()`

The Typster enemy type has also been introduced, inheriting from the
base entity type. The game manager now internally keeps a list of game
entities, with the Typster enemy type being the first to be registered.

This pull request closes #10 