### PR TITLE
Add keyboard manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SRC := src/merak/screen.c src/merak/game.c src/merak/entity.c \
        src/merak/event.c src/enemy.c src/merak/vector.c \
-       src/merak/texture.c src/merak/sprite.c src/typster.c
+       src/merak/texture.c src/merak/sprite.c src/typster.c \
+       src/merak/keyboard.c src/merak/arena.c
 INC := -I "../"
 LIB := ../sol/bld/bin/libsol.so
 

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -8,14 +8,32 @@ static sol_erno delegate_update(merak_entity *enemy)
 {
         const sol_index row = 1;
         const sol_index col = ((SDL_GetTicks() / 100) % 4) + 1;
+        const sol_float x = (sol_float) 0.1;
+        const sol_float y = (sol_float) 0.0;
+        auto merak_vector *velocity = SOL_PTR_NULL;
+        auto MERAK_KEYBOARD_STATE left, right;
 
 SOL_TRY:
+        sol_try (merak_keyboard_state(MERAK_KEYBOARD_KEY_LEFT, &left));
+        if (left == MERAK_KEYBOARD_STATE_DOWN) {
+                sol_try (merak_vector_new2(&velocity, -x, y));
+                sol_try (merak_entity_move(enemy, velocity));
+        }
+
+        sol_try (merak_keyboard_state(MERAK_KEYBOARD_KEY_RIGHT, &right));
+        if (right == MERAK_KEYBOARD_STATE_DOWN) {
+                merak_vector_free(&velocity);
+                sol_try (merak_vector_new2(&velocity, x, y));
+                sol_try (merak_entity_move(enemy, velocity));
+        }
+
         sol_try(merak_entity_setframe(enemy, row, col));
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
 
 SOL_FINALLY:
+        merak_vector_free(&velocity);
         return sol_erno_get();
 }
 

--- a/src/merak/arena.c
+++ b/src/merak/arena.c
@@ -1,0 +1,154 @@
+#include "merak.h"
+
+
+
+
+struct arena_list_node {
+        merak_entity *elem;
+        struct arena_list_node *next;
+};
+
+
+
+
+struct arena_list {
+        struct arena_list_node *head;
+        struct arena_list_node *tail;
+        struct arena_list_node *curr;
+        sol_size nelem;
+};
+
+
+
+
+static sol_tls struct arena_list *arena_entities = SOL_PTR_NULL;
+
+
+
+
+extern sol_erno merak_arena_init(void)
+{
+SOL_TRY:
+        sol_assert (!arena_entities, SOL_ERNO_STATE);
+
+        sol_try (sol_ptr_new((sol_ptr **) &arena_entities,
+                             sizeof (*arena_entities)));
+
+        arena_entities->head = SOL_PTR_NULL;
+        arena_entities->tail = SOL_PTR_NULL;
+        arena_entities->curr = SOL_PTR_NULL;
+        arena_entities->nelem = (sol_size) 0;
+
+        sol_log_trace("arena initialised");
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern void merak_arena_exit(void)
+{
+        auto struct arena_list_node *node;
+
+        if (sol_likely (arena_entities)) {
+                arena_entities->curr = arena_entities->head;
+
+                while ((node = arena_entities->curr)) {
+                        arena_entities->curr = arena_entities->curr->next;
+
+                        merak_entity_free(&node->elem);
+                        sol_ptr_free((sol_ptr **) &node);
+                }
+        }
+
+        sol_ptr_free((sol_ptr **) &arena_entities);
+        sol_log_trace("arena exited");
+}
+
+
+
+
+extern sol_erno merak_arena_push(merak_entity *entity)
+{
+        auto struct arena_list_node *node = SOL_PTR_NULL;
+
+SOL_TRY:
+        sol_assert (arena_entities, SOL_ERNO_STATE);
+        sol_assert (entity, SOL_ERNO_PTR);
+
+        sol_try (sol_ptr_new((sol_ptr **) &node, sizeof (*node)));
+        node->elem = SOL_PTR_NULL;
+        node->next = SOL_PTR_NULL;
+
+        sol_try (merak_entity_copy(&node->elem, entity));
+
+        if (!arena_entities->head)
+                arena_entities->head = node;
+
+        if (arena_entities->tail)
+                arena_entities->tail->next = node;
+
+        arena_entities->tail = node;
+        arena_entities->nelem++;
+
+SOL_CATCH:
+        if (node) {
+                merak_entity_free(&node->elem);
+                sol_ptr_free((sol_ptr **) &node);
+        }
+
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_arena_update(void)
+{
+SOL_TRY:
+        sol_assert (arena_entities, SOL_ERNO_STATE);
+
+        arena_entities->curr = arena_entities->head;
+
+        while (arena_entities->curr) {
+                sol_try (merak_entity_update(arena_entities->curr->elem));
+                arena_entities->curr = arena_entities->curr->next;
+        }
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+extern sol_erno merak_arena_draw(void)
+{
+SOL_TRY:
+        sol_assert (arena_entities, SOL_ERNO_STATE);
+
+        arena_entities->curr = arena_entities->head;
+
+        while (arena_entities->curr) {
+                sol_try (merak_entity_draw(arena_entities->curr->elem));
+                arena_entities->curr = arena_entities->curr->next;
+        }
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+

--- a/src/merak/entity.c
+++ b/src/merak/entity.c
@@ -23,9 +23,7 @@ static sol_inline SOL_BOOL float_lt(sol_float lhs, sol_float rhs)
 
         return (rhs - lhs) > ((fabs(lhs) < fabs(rhs)
                               ? fabs(rhs)
-                              : fabs(lhs)) * epsilon)
-               ? SOL_BOOL_TRUE
-               : SOL_BOOL_FALSE;
+                              : fabs(lhs)) * epsilon);
 }
 
 
@@ -41,7 +39,7 @@ SOL_TRY:
         sol_assert (entity, SOL_ERNO_PTR);
 
         sol_try (merak_vector_x(entity->vec, &x));
-        sol_try (merak_vector_x(entity->vec, &y));
+        sol_try (merak_vector_y(entity->vec, &y));
 
         if (sol_likely (!float_lt(x, zero) && !float_lt(y, zero))) {
                 pos.x = (sol_u16) x;
@@ -135,6 +133,8 @@ SOL_TRY:
         ctx->dispose = dispose;
         ctx->draw = draw;
 
+        sol_log_trace("new entity created");
+
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
 
@@ -176,6 +176,7 @@ extern void merak_entity_free(merak_entity **entity)
         }
 
         sol_ptr_free((sol_ptr **) entity);
+        sol_log_trace("entity destroyed");
 }
 
 

--- a/src/merak/event.c
+++ b/src/merak/event.c
@@ -4,8 +4,31 @@
 
 
 
+#define EVENT_COUNT 3
+
+
+
+
+static sol_tls SOL_BOOL event_init = SOL_BOOL_FALSE;
+
+
+
+
+static sol_inline void event_exit(void)
+{
+        merak_screen_exit();
+        merak_keyboard_exit();
+        merak_event_exit();
+        merak_arena_exit();
+        merak_game_exit();
+}
+
+
+
+
 extern sol_erno merak_event_init(void)
 {
+        event_init = SOL_BOOL_TRUE;
         return SOL_ERNO_NULL;
 }
 
@@ -14,33 +37,42 @@ extern sol_erno merak_event_init(void)
 
 extern void merak_event_exit(void)
 {
+        event_init = SOL_BOOL_FALSE;
 }
 
 
 
 
-extern sol_erno merak_event_poll(MERAK_EVENT_CODE *code)
+extern sol_erno merak_event_update(void)
 {
         auto SDL_Event event;
-        auto sol_int more;
 
-        more = SDL_PollEvent(&event);
+SOL_TRY:
+        sol_assert (event_init, SOL_ERNO_STATE);
 
-        if (sol_likely (more)) {
+        while (SDL_PollEvent(&event)) {
                 switch (event.type) {
                 case SDL_QUIT:
-                        *code = MERAK_EVENT_CODE_QUIT;
+                        event_exit();
+                        break;
+
+                case SDL_KEYUP:
+                        sol_try (merak_keyboard_update());
+                        break;
+
+                case SDL_KEYDOWN:
+                        sol_try (merak_keyboard_update());
                         break;
 
                 default:
-                        *code = MERAK_EVENT_CODE_IGNORED;
                         break;
                 }
         }
-        else {
-                *code = MERAK_EVENT_CODE_NULL;
-        }
 
-        return SOL_ERNO_NULL;
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
 }
 

--- a/src/merak/game.c
+++ b/src/merak/game.c
@@ -6,29 +6,9 @@
 
 
 
-struct list_node {
-        merak_entity *elem;
-        struct list_node *next;
-};
-
-
-
-
-struct list {
-        struct list_node *head;
-        struct list_node *tail;
-        struct list_node *curr;
-        sol_size nelem;
-};
-
-
-
-
 struct game {
-        merak_game_delegate *input;
         merak_game_delegate *update;
         merak_game_delegate *render;
-        struct list *entities;
 };
 
 
@@ -37,144 +17,18 @@ struct game {
 static sol_tls struct game *game_inst = SOL_PTR_NULL;
 
 
-
-
-static sol_erno list_new(struct list **list)
-{
-        auto struct list *hnd;
-
-SOL_TRY:
-        sol_assert (list, SOL_ERNO_PTR);
-
-        sol_try (sol_ptr_new((sol_ptr **) list, sizeof (**list)));
-        hnd = *list;
-
-        hnd->head = SOL_PTR_NULL;
-        hnd->tail = SOL_PTR_NULL;
-        hnd->curr = SOL_PTR_NULL;
-        hnd->nelem = (sol_size) 0;
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-static void list_free(struct list **list)
-{
-        auto struct list *hnd;
-        auto struct list_node *node;
-
-        if (sol_likely (list && (hnd = *list))) {
-                hnd->curr = hnd->head;
-
-                while ((node = hnd->curr)) {
-                        hnd->curr = hnd->curr->next;
-
-                        merak_entity_free(&node->elem);
-                        sol_ptr_free((sol_ptr **) &node);
-                }
-
-                sol_ptr_free ((sol_ptr **) list);
-        }
-}
-
-
-
-
-static sol_erno list_push(struct list *list, merak_entity *elem)
-{
-        auto struct list_node *node = SOL_PTR_NULL;
-
-SOL_TRY:
-        sol_assert (list && elem, SOL_ERNO_PTR);
-
-        sol_try (sol_ptr_new((sol_ptr **) &node, sizeof (*node)));
-
-        node->elem = SOL_PTR_NULL;
-        node->next = SOL_PTR_NULL;
-
-        sol_try (merak_entity_copy(&node->elem, elem));
-
-        if (!list->head)
-                list->head = node;
-
-        if (list->tail)
-                list->tail->next = node;
-
-        list->tail = node;
-        list->nelem++;
-
-SOL_CATCH:
-        if (node) {
-                merak_entity_free(&node->elem);
-                sol_ptr_free((sol_ptr **) &node);
-        }
-
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-static sol_erno list_start(struct list *list)
-{
-SOL_TRY:
-        sol_assert (list, SOL_ERNO_PTR);
-
-        list->curr = list->head;
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-static sol_erno list_next(struct list *list)
-{
-SOL_TRY:
-        sol_assert (list, SOL_ERNO_PTR);
-
-        list->curr = list->curr->next;
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-extern sol_erno merak_game_init(merak_game_delegate *input,
-                                merak_game_delegate *update,
+extern sol_erno merak_game_init(merak_game_delegate *update,
                                 merak_game_delegate *render)
 {
         const int iflag = IMG_INIT_PNG;
 
 SOL_TRY:
-        sol_assert (input && update && render, SOL_ERNO_PTR);
+        sol_assert (update && render, SOL_ERNO_PTR);
         sol_assert (!game_inst, SOL_ERNO_STATE);
 
         sol_try (sol_ptr_new((sol_ptr **) &game_inst, sizeof (*game_inst)));
-        game_inst->input = input;
         game_inst->update = update;
         game_inst->render = render;
-
-        game_inst->entities = SOL_PTR_NULL;
-        sol_try (list_new(&game_inst->entities));
 
         sol_assert (SDL_Init(SDL_INIT_EVERYTHING) >= 0, SOL_ERNO_STATE);
         sol_assert ((IMG_Init(iflag) & iflag) == iflag, SOL_ERNO_STATE);
@@ -195,7 +49,6 @@ SOL_FINALLY:
 extern void merak_game_exit(void)
 {
         if (sol_likely (game_inst)) {
-                list_free(&game_inst->entities);
                 sol_ptr_free((sol_ptr **) &game_inst);
 
                 SDL_Quit();
@@ -208,52 +61,18 @@ extern void merak_game_exit(void)
 
 
 
-extern sol_erno merak_game_register(merak_entity *entity)
-{
-SOL_TRY:
-        sol_assert (entity, SOL_ERNO_PTR);
-        sol_assert (game_inst, SOL_ERNO_STATE);
-
-        sol_try (list_push(game_inst->entities, entity));
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
 extern sol_erno merak_game_run(void)
 {
-        auto struct list_node *curr;
-
 SOL_TRY:
         sol_assert (game_inst, SOL_ERNO_STATE);
 
         while (SOL_BOOL_TRUE) {
-                sol_try (game_inst->input());
-
                 sol_try (game_inst->update());
-                sol_try (list_start(game_inst->entities));
-
-                while ((curr = game_inst->entities->curr)) {
-                        sol_try (merak_entity_update(curr->elem));
-                        sol_try (merak_entity_draw(curr->elem));
-
-                        sol_try (list_next(game_inst->entities));
-                }
+                sol_try (merak_event_update());
+                sol_try (merak_arena_update());
 
                 sol_try (game_inst->render());
-                sol_try (list_start(game_inst->entities));
-
-                while ((curr = game_inst->entities->curr)) {
-                        sol_try (merak_entity_draw(curr->elem));
-                        sol_try (list_next(game_inst->entities));
-                }
-
+                sol_try (merak_arena_draw());
                 sol_try (merak_screen_render());
         }
 

--- a/src/merak/keyboard.c
+++ b/src/merak/keyboard.c
@@ -1,0 +1,126 @@
+/******************************************************************************
+ *                               MERAK LIBRARY
+ *
+ * File: merak/src/vector.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Merak Library.
+ *      It implements the keyboard manager interface.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "merak.h"
+#include <SDL2/SDL.h>
+
+
+
+
+        /* declare the thread-local array of key states; we'll use this array to
+         * store the key states as reported by SDL; we're initialising this
+         * array to a null pointer to indicate that the keyboard manager hasn't
+         * been initialised yet */
+static sol_tls const sol_u8 *key_states = SOL_PTR_NULL;
+
+
+
+
+        /* define the `merak_keyboard_init()` interface function; although not
+         * required, we enforce the policy that a call to this function is
+         * allowed only if the keyboard manager hasn't been initialised (as
+         * determined by whether or not `key_states` is null); on
+         * initialisation, we poll SDL for the current keyboard state */
+extern sol_erno merak_keyboard_init(void)
+{
+SOL_TRY:
+        sol_assert (!key_states, SOL_ERNO_STATE);
+
+        key_states = SDL_GetKeyboardState(SOL_PTR_NULL);
+        sol_assert (key_states, SOL_ERNO_STATE);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* define the `merak_keyboard_exit()` interface function; by setting the
+         * `key_states` thread-local variable to null, we indicate that the
+         * keyboard manager has been released */
+extern void merak_keyboard_exit(void)
+{
+        key_states = SOL_PTR_NULL;
+}
+
+
+
+
+        /* define the `merak_keyboard_state()` interface function; since there's
+         * a one-to-one correspondence between the `MERAK_KEYBOARD_KEY`
+         * enumerated values and the keyboard scan codes used by SDL (as both
+         * follow the USB HID protocol), we can use the `key` argument as the
+         * index of `key_states` */
+extern sol_hot sol_erno merak_keyboard_state(const MERAK_KEYBOARD_KEY key,
+                                             MERAK_KEYBOARD_STATE *state)
+{
+SOL_TRY:
+        sol_assert (key_states, SOL_ERNO_STATE);
+        sol_assert (state, SOL_ERNO_PTR);
+
+        *state = key_states[key];
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* define the `merak_keyboard_update()` interface function; we poll SDL
+         * to determine the current keyboard state */
+extern sol_hot sol_erno merak_keyboard_update(void)
+{
+SOL_TRY:
+        sol_assert (key_states, SOL_ERNO_STATE);
+
+        key_states = SDL_GetKeyboardState(SOL_PTR_NULL);
+        sol_assert (key_states, SOL_ERNO_STATE);
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ ******************************************************************************/
+

--- a/src/merak/merak.h
+++ b/src/merak/merak.h
@@ -70,8 +70,73 @@ typedef struct __merak_area {
 
 /*
  * Interface: vector
+ *
+ * Abstract:
+ *      A vector in Merak is similar to the mathematical concept of a vector. It
+ *      is a construct that represents both a magnitude along with a direction
+ *      in 2D space. Using this definition, a vector can be used to represent a
+ *      change in spatial orientation from a given location. A vector may also
+ *      represent a point in 2D space as a change of given magnitude and
+ *      direction from the origin.
+ *
+ *      A vector in Merak has the following properties:
+ *        - an x co-ordinate,
+ *        - a y co-ordinate, and
+ *        - a length (magnitude)
+ *
+ *     Two vectors may be compared by comparing their lengths; thus two vectors
+ *     are equal if their lengths are equal. A vector with a length of zero is
+ *     called a null vector. A vector may be added and subtracted with another
+ *     vector (called the velocity vector), resulting in a change in both
+ *     magnitude and direction. A vector may be multiplied and divided by a
+ *     scalar (magnitude), in which case there is only a change in the length,
+ *     but not in the direction.
+ *
+ *     The normal form of a vector is a vector with the same direction, but with
+ *     the inverse of its original magnitude as its length.
+ *
+ * Detail:
+ *      A vector in Merak is represented by the opaque type `merak_vector`. The
+ *      functions that form the interface for `merak_vector` return a `sol_erno`
+ *      error code to indicate whether or not the operation succeeded. The
+ *      notable exception to this is the `merak_vector_free()` function, which
+ *      returns `void`, since it's a finalisation routine.
+ *
+ *      The first parameter of all the interface functions takes a handle to a
+ *      `merak_vector` instance. A `merak_vector **` handle indicates that a new
+ *      `merak_vector` instance will be created, a `merak_vector *` handle
+ *      indicates that an existing instance will be modified, and a `const
+ *      merak_vector *` handle indicates that an existing instance won't be
+ *      modified.
+ *
+ *      Assumptions.
+ *
+ *      The interface for `merak_vector` provides four housekeeping functions.
+ *      `merak_vector_new()` and `merak_vector_new2()` are responsible for
+ *      creating a new `merak_vector` instance. The former initialises the newly
+ *      created instance to a null vector, whereas the latter initialises the
+ *      instance with specific coordinates. `merak_vector_copy()` creates a copy
+ *      of an existing instance, and `merak_vector_free()` destroys an existing
+ *      instance by releasing the resources allocated to it.
+ *
+ *      There are three accessor functions for a `merak_vector` instance.
+ *      `merak_vector_x()` and `merak_vector_y()` get the x and y coordinates
+ *      respectively of `merak_vector` instance, and `merak_vector_len()` gets
+ *      length.
+ *
+ *      There are three mutator functions for a `merak_vector` instance.
+ *      `merak_vector_setx()` and `merak_vector_sety()` set the x and y
+ *      coordinates respectively of the instance, and `merak_vector_norm()`
+ *      transforms the instance to its normal form.
+ *
+ *      There are seven operator functions for a `merak_vector` instance.
+ *      `merak_vector_lt()`, `merak_vector_eq()`, and `merak_vector_gt()`
+ *      compare, respectively, whether a `merak_vector` instance is less than,
+ *      equal to, or greater than another instance. `merak_vector_add()` and
+ *      `merak_vector_sub()` add and subtract respectively one instance with
+ *      another. `merak_vector_mul()` and `merak_vector_div()` multiplies and
+ *      divides respectively an instance with a scalar.
  */
-
 typedef struct __merak_vector merak_vector;
 
 extern sol_erno merak_vector_new(merak_vector **vec);
@@ -94,6 +159,8 @@ extern sol_erno merak_vector_setx(merak_vector *vec, const sol_float x);
 
 extern sol_erno merak_vector_sety(merak_vector *vec, const sol_float y);
 
+extern sol_erno merak_vector_norm(merak_vector *vec);
+
 extern sol_erno merak_vector_lt(const merak_vector *lhs,
                                 const merak_vector *rhs,
                                 SOL_BOOL *lt);
@@ -108,21 +175,11 @@ extern sol_erno merak_vector_gt(const merak_vector *lhs,
 
 extern sol_erno merak_vector_add(merak_vector *lhs, const merak_vector *rhs);
 
-extern sol_erno merak_vector_add2(merak_vector *vec,
-                                  const sol_float x,
-                                  const sol_float y);
-
 extern sol_erno merak_vector_sub(merak_vector *lhs, const merak_vector *rhs);
-
-extern sol_erno merak_vector_sub2(merak_vector *vec,
-                                  const sol_float x,
-                                  const sol_float y);
 
 extern sol_erno merak_vector_mul(merak_vector *vec, const sol_float scalar);
 
 extern sol_erno merak_vector_div(merak_vector *vec, const sol_float scalar);
-
-extern sol_erno merak_vector_norm(merak_vector *vec);
 
 
 
@@ -161,19 +218,212 @@ extern sol_erno merak_screen_render(void);
 
 
 /*
- * Interface: event
+ * Interface: keyboard manager
+ *
+ * Abstract:
+ *      The keyboard is probably the most important input device for games (at
+ *      least on PCs). Although modern USB keyboards have many varieties, and
+ *      support several additional keys for internationalisation, the Merak
+ *      keyboard manager uses only a subset of the key codes defined by the USB
+ *      HID protocol.
+ *
+ *      This subset accounts for the common US keyboard layout (plus the non-US
+ *      variation on the backslash key) along with the common media keys. I'm
+ *      guessing that this subset should also be good enough for Mac keyboards.
+ *
+ * Description:
+ *      The keyboard is not represented by any type in Merak; instead, there is
+ *      only an interface through which the common keyboard operations are
+ *      performed. The functions that form this interface return a `sol_erno`
+ *      error code to indicate whether or not the operation succeeded. The only
+ *      exception is `merak_keyboard_exit()`, which returns `void` since it's a
+ *      finalisation routine.
+ *
+ *      Supporting this interface are two enumerations: `MERAK_KEYBOARD_KEY` and
+ *      `MERAK_KEYBOARD_STATE` which, respectively, enumerate the common
+ *      keyboard key codes, and the keyboard key states. The values enumerated
+ *      by `MERAK_KEYBOARD_KEY` follow the USB HID protocol.
+ *
+ *      The keyboard manager interface provides two houskeeping functions.
+ *      `merak_keyboard_init()` is used to initialise the keyboard manager, and
+ *      `merak_keyboard_exit()` is used to release it.
+ *
+ *      There is only one accessor function in the keyboard manager interface.
+ *      `merak_keyboard_state()` determines the current state (enumerated by
+ *      `MERAK_KEYBOARD_STATE`) of a given keyboard key (enumerated by
+ *      `MERAK_KEYBOARD_KEY`.
+ *
+ *      The `merak_keyboard_update()` function is the only mutator in the
+ *      keyboard manager interface. This function updates the current state of
+ *      the keyboard manager, and is triggered automatically during the game
+ *      loop when a keyboard key is pressed. For this reason, it's not required
+ *      to call this function before making a call to `merak_keyboard_state()`.
+ *
+ * Usage:
+ *      The first step in using the keyboard manager is to initialise it only
+ *      **once** at the start of the game by a call to `merak_keyboard_init()`.
+ *      A `SOL_ERNO_STATE` error is thrown in case `merak_keyboard_init()` is
+ *      called after the keyboard manager has already been initialised.
+ *
+ *      Typically, you would call `merak_keyboard_state()` whenever you need to
+ *      determine which key of the keyboard has been pressed. As mentioned
+ *      earlier, it's not necessary to call `merak_keyboard_update()` before
+ *      this as the game loop already takes care of calling it whenever a
+ *      keyboard event is fired.
+ *
+ *      Once you're through with the game and are winding up, you'd need to call
+ *      `merak_keyboard_exit()` to release the keyboard manager.
+ *
+ * References:
+ *   1. https://gist.github.com/MightyPork/6da26e382a7ad91b5496ee55fdc73db2
  */
-typedef enum __MERAK_EVENT_CODE {
-        MERAK_EVENT_CODE_IGNORED = -1,
-        MERAK_EVENT_CODE_NULL = 0,
-        MERAK_EVENT_CODE_QUIT
-} MERAK_EVENT_CODE;
+typedef enum __MERAK_KEYBOARD_KEY {
+        MERAK_KEYBOARD_KEY_NONE = 0x00,     /* No key pressed */
+        MERAK_KEYBOARD_KEY_OVERFLOW = 0x01, /* Too many keys pressed */
 
-extern sol_erno merak_event_init(void);
+        MERAK_KEYBOARD_KEY_A = 0x04, /* Keyboard a and A */
+        MERAK_KEYBOARD_KEY_B = 0x05, /* Keyboard b and B */
+        MERAK_KEYBOARD_KEY_C = 0x06, /* Keyboard c and C */
+        MERAK_KEYBOARD_KEY_D = 0x07, /* Keyboard d and D */
+        MERAK_KEYBOARD_KEY_E = 0x08, /* Keyboard e and E */
+        MERAK_KEYBOARD_KEY_F = 0x09, /* Keyboard f and F */
+        MERAK_KEYBOARD_KEY_G = 0x0a, /* Keyboard g and G */
+        MERAK_KEYBOARD_KEY_H = 0x0b, /* Keyboard h and H */
+        MERAK_KEYBOARD_KEY_I = 0x0c, /* Keyboard i and I */
+        MERAK_KEYBOARD_KEY_J = 0x0d, /* Keyboard j and J */
+        MERAK_KEYBOARD_KEY_K = 0x0e, /* Keyboard k and K */
+        MERAK_KEYBOARD_KEY_L = 0x0f, /* Keyboard l and L */
+        MERAK_KEYBOARD_KEY_M = 0x10, /* Keyboard m and M */
+        MERAK_KEYBOARD_KEY_N = 0x11, /* Keyboard n and N */
+        MERAK_KEYBOARD_KEY_O = 0x12, /* Keyboard o and O */
+        MERAK_KEYBOARD_KEY_P = 0x13, /* Keyboard p and P */
+        MERAK_KEYBOARD_KEY_Q = 0x14, /* Keyboard q and Q */
+        MERAK_KEYBOARD_KEY_R = 0x15, /* Keyboard r and R */
+        MERAK_KEYBOARD_KEY_S = 0x16, /* Keyboard s and S */
+        MERAK_KEYBOARD_KEY_T = 0x17, /* Keyboard t and T */
+        MERAK_KEYBOARD_KEY_U = 0x18, /* Keyboard u and U */
+        MERAK_KEYBOARD_KEY_V = 0x19, /* Keyboard v and V */
+        MERAK_KEYBOARD_KEY_W = 0x1a, /* Keyboard w and W */
+        MERAK_KEYBOARD_KEY_X = 0x1b, /* Keyboard x and X */
+        MERAK_KEYBOARD_KEY_Y = 0x1c, /* Keyboard y and Y */
+        MERAK_KEYBOARD_KEY_Z = 0x1d, /* Keyboard z and Z */
 
-extern void merak_event_exit(void);
+        MERAK_KEYBOARD_KEY_1 = 0x1e, /* Keyboard 1 and ! */
+        MERAK_KEYBOARD_KEY_2 = 0x1f, /* Keyboard 2 and @ */
+        MERAK_KEYBOARD_KEY_3 = 0x20, /* Keyboard 3 and # */
+        MERAK_KEYBOARD_KEY_4 = 0x21, /* Keyboard 4 and $ */
+        MERAK_KEYBOARD_KEY_5 = 0x22, /* Keyboard 5 and % */
+        MERAK_KEYBOARD_KEY_6 = 0x23, /* Keyboard 6 and ^ */
+        MERAK_KEYBOARD_KEY_7 = 0x24, /* Keyboard 7 and & */
+        MERAK_KEYBOARD_KEY_8 = 0x25, /* Keyboard 8 and * */
+        MERAK_KEYBOARD_KEY_9 = 0x26, /* Keyboard 9 and ( */
+        MERAK_KEYBOARD_KEY_0 = 0x27, /* Keyboard 0 and ) */
 
-extern sol_erno merak_event_poll(MERAK_EVENT_CODE *code);
+        MERAK_KEYBOARD_KEY_ENTER = 0x28,      /* Keyboard Enter */
+        MERAK_KEYBOARD_KEY_ESC = 0x29,        /* Keyboard Escape */
+        MERAK_KEYBOARD_KEY_BKSPACE = 0x2a,    /* Keyboard Backspace */
+        MERAK_KEYBOARD_KEY_TAB = 0x2b,        /* Keyboard Tab */
+        MERAK_KEYBOARD_KEY_SPACE = 0x2c,      /* Keyboard Spacebar */
+        MERAK_KEYBOARD_KEY_MINUS = 0x2d,      /* Keyboard - and _ */
+        MERAK_KEYBOARD_KEY_EQUAL = 0x2e,      /* Keyboard = and + */
+        MERAK_KEYBOARD_KEY_LBRACE = 0x2f,     /* Keyboard [ and { */
+        MERAK_KEYBOARD_KEY_RBRACE = 0x30,     /* Keyboard ] and } */
+        MERAK_KEYBOARD_KEY_BKSLASH = 0x31,    /* Keyboard \ and | */
+        MERAK_KEYBOARD_KEY_HASHTILDE = 0x32,  /* Keyboard Non-US # and ~ */
+        MERAK_KEYBOARD_KEY_SEMICOLON = 0x33,  /* Keyboard ; and : */
+        MERAK_KEYBOARD_KEY_APOSTROPHE = 0x34, /* Keyboard ' and " */
+        MERAK_KEYBOARD_KEY_GRAVE = 0x35,      /* Keyboard ` and ~ */
+        MERAK_KEYBOARD_KEY_COMMA = 0x36,      /* Keyboard , and < */
+        MERAK_KEYBOARD_KEY_DOT = 0x37,        /* Keyboard . and > */
+        MERAK_KEYBOARD_KEY_SLASH = 0x38,      /* Keyboard / and ? */
+        MERAK_KEYBOARD_KEY_CAPSLOCK = 0x39,   /* Keyboard Caps Lock */
+
+        MERAK_KEYBOARD_KEY_F1 = 0x3a,  /* Keyboard F1 */
+        MERAK_KEYBOARD_KEY_F2 = 0x3b,  /* Keyboard F2 */
+        MERAK_KEYBOARD_KEY_F3 = 0x3c,  /* Keyboard F3 */
+        MERAK_KEYBOARD_KEY_F4 = 0x3d,  /* Keyboard F4 */
+        MERAK_KEYBOARD_KEY_F5 = 0x3e,  /* Keyboard F5 */
+        MERAK_KEYBOARD_KEY_F6 = 0x3f,  /* Keyboard F6 */
+        MERAK_KEYBOARD_KEY_F7 = 0x40,  /* Keyboard F7 */
+        MERAK_KEYBOARD_KEY_F8 = 0x41,  /* Keyboard F8 */
+        MERAK_KEYBOARD_KEY_F9 = 0x42,  /* Keyboard F9 */
+        MERAK_KEYBOARD_KEY_F10 = 0x43, /* Keyboard F10 */
+        MERAK_KEYBOARD_KEY_F11 = 0x44, /* Keyboard F11 */
+        MERAK_KEYBOARD_KEY_F12 = 0x45, /* Keyboard F12 */
+
+        MERAK_KEYBOARD_KEY_SYSRQ = 0x46,      /* Keyboard Print Screen */
+        MERAK_KEYBOARD_KEY_SCROLLLOCK = 0x47, /* Keyboard Scroll Lock */
+        MERAK_KEYBOARD_KEY_PAUSE = 0x48,      /* Keyboard Pause */
+        MERAK_KEYBOARD_KEY_INSERT = 0x49,     /* Keyboard Insert */
+        MERAK_KEYBOARD_KEY_HOME = 0x4a,       /* Keyboard Home */
+        MERAK_KEYBOARD_KEY_PAGEUP = 0x4b,     /* Keyboard Page Up */
+        MERAK_KEYBOARD_KEY_DELETE = 0x4c,     /* Keyboard Delete */
+        MERAK_KEYBOARD_KEY_END = 0x4d,        /* Keyboard End */
+        MERAK_KEYBOARD_KEY_PAGEDOWN = 0x4e,   /* Keyboard Page Down */
+        MERAK_KEYBOARD_KEY_RIGHT = 0x4f,      /* Keyboard Right Arrow */
+        MERAK_KEYBOARD_KEY_LEFT = 0x50,       /* Keyboard Left Arrow */
+        MERAK_KEYBOARD_KEY_DOWN = 0x51,       /* Keyboard Down Arrow */
+        MERAK_KEYBOARD_KEY_UP = 0x52,         /* Keyboard Up Arrow */
+
+        MERAK_KEYBOARD_KEY_NUMLOCK = 0x53,    /* Keyboard Num Lock and Clear */
+        MERAK_KEYBOARD_KEY_KPSLASH = 0x54,    /* Keypad / */
+        MERAK_KEYBOARD_KEY_KPASTERISK = 0x55, /* Keypad * */
+        MERAK_KEYBOARD_KEY_KPMINUS = 0x56,    /* Keypad - */
+        MERAK_KEYBOARD_KEY_KPPLUS = 0x57,     /* Keypad + */
+        MERAK_KEYBOARD_KEY_KPENTER = 0x58,    /* Keypad Enter */
+        MERAK_KEYBOARD_KEY_KP1 = 0x59,        /* Keypad 1 and End */
+        MERAK_KEYBOARD_KEY_KP2 = 0x5a,        /* Keypad 2 and Down Arrow */
+        MERAK_KEYBOARD_KEY_KP3 = 0x5b,        /* Keypad 3 and PageDn */
+        MERAK_KEYBOARD_KEY_KP4 = 0x5c,        /* Keypad 4 and Left Arrow */
+        MERAK_KEYBOARD_KEY_KP5 = 0x5d,        /* Keypad 5 */
+        MERAK_KEYBOARD_KEY_KP6 = 0x5e,        /* Keypad 6 and Right Arrow */
+        MERAK_KEYBOARD_KEY_KP7 = 0x5f,        /* Keypad 7 and Home */
+        MERAK_KEYBOARD_KEY_KP8 = 0x60,        /* Keypad 8 and Up Arrow */
+        MERAK_KEYBOARD_KEY_KP9 = 0x61,        /* Keypad 9 and Page Up */
+        MERAK_KEYBOARD_KEY_KP0 = 0x62,        /* Keypad 0 and Insert */
+        MERAK_KEYBOARD_KEY_KPDOT = 0x63,      /* Keypad . and Delete */
+
+        MERAK_KEYBOARD_KEY_102ND = 0x64,      /* Keyboard Non-US \ and | */
+        MERAK_KEYBOARD_KEY_COMPOSE = 0x65,    /* Keyboard Application */
+        MERAK_KEYBOARD_KEY_POWER = 0x66,      /* Keyboard Power */
+        MERAK_KEYBOARD_KEY_OPEN = 0x74,       /* Keyboard Execute */
+        MERAK_KEYBOARD_KEY_HELP = 0x75,       /* Keyboard Help */
+        MERAK_KEYBOARD_KEY_PROPS = 0x76,      /* Keyboard Menu */
+        MERAK_KEYBOARD_KEY_FRONT = 0x77,      /* Keyboard Select */
+        MERAK_KEYBOARD_KEY_STOP = 0x78,       /* Keyboard Stop */
+        MERAK_KEYBOARD_KEY_AGAIN = 0x79,      /* Keyboard Again */
+        MERAK_KEYBOARD_KEY_UNDO = 0x7a,       /* Keyboard Undo */
+        MERAK_KEYBOARD_KEY_CUT = 0x7b,        /* Keyboard Cut */
+        MERAK_KEYBOARD_KEY_COPY = 0x7c,       /* Keyboard Copy */
+        MERAK_KEYBOARD_KEY_PASTE = 0x7d,      /* Keyboard Paste */
+        MERAK_KEYBOARD_KEY_FIND = 0x7e,       /* Keyboard Find */
+        MERAK_KEYBOARD_KEY_MUTE = 0x7f,       /* Keyboard Mute */
+        MERAK_KEYBOARD_KEY_VOLUMEUP = 0x80,   /* Keyboard Volume Up */
+        MERAK_KEYBOARD_KEY_VOLUMEDOWN = 0x81, /* Keyboard Volume Down */
+
+        MERAK_KEYBOARD_KEY_LCTRL = 0xe0,  /* Keyboard Left Control */
+        MERAK_KEYBOARD_KEY_LSHIFT = 0xe1, /* Keyboard Left Shift */
+        MERAK_KEYBOARD_KEY_LALT = 0xe2,   /* Keyboard Left Alt */
+        MERAK_KEYBOARD_KEY_LMETA = 0xe3,  /* Keyboard Left GUI */
+        MERAK_KEYBOARD_KEY_RCTRL = 0xe4,  /* Keyboard Right Control */
+        MERAK_KEYBOARD_KEY_RSHIFT = 0xe5, /* Keyboard Right Shift */
+        MERAK_KEYBOARD_KEY_RALT = 0xe6,   /* Keyboard Right Alt */
+        MERAK_KEYBOARD_KEY_RMETA = 0xe7,  /* Keyboard Right GUI */
+} MERAK_KEYBOARD_KEY;
+
+typedef enum __MERAK_KEYBOARD_STATE {
+        MERAK_KEYBOARD_STATE_UP = 0,
+        MERAK_KEYBOARD_STATE_DOWN
+} MERAK_KEYBOARD_STATE;
+
+extern sol_erno merak_keyboard_init(void);
+
+extern void merak_keyboard_exit(void);
+
+extern sol_hot sol_erno merak_keyboard_state(const MERAK_KEYBOARD_KEY key,
+                                             MERAK_KEYBOARD_STATE *state);
+
+extern sol_hot sol_erno merak_keyboard_update(void);
 
 
 
@@ -284,19 +534,45 @@ extern sol_erno merak_entity_draw(merak_entity *entity);
 
 
 /*
+ * Interface: arena
+ */
+
+extern sol_erno merak_arena_init(void);
+
+extern void merak_arena_exit(void);
+
+extern sol_erno merak_arena_push(merak_entity *entity);
+
+extern sol_erno merak_arena_update(void);
+
+extern sol_erno merak_arena_draw(void);
+
+
+
+
+/*
  * Interface: game
  */
 typedef sol_erno (merak_game_delegate)(void);
 
-extern sol_erno merak_game_init(merak_game_delegate *input,
-                                merak_game_delegate *update,
+extern sol_erno merak_game_init(merak_game_delegate *update,
                                 merak_game_delegate *render);
 
 extern void merak_game_exit(void);
 
-extern sol_erno merak_game_register(merak_entity *entity);
-
 extern sol_erno merak_game_run(void);
+
+
+
+
+/*
+ * Interface: event
+ */
+extern sol_erno merak_event_init(void);
+
+extern void merak_event_exit(void);
+
+extern sol_erno merak_event_update(void);
 
 
 

--- a/src/merak/vector.c
+++ b/src/merak/vector.c
@@ -1,9 +1,42 @@
+/******************************************************************************
+ *                               MERAK LIBRARY
+ *
+ * File: merak/src/vector.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Merak Library.
+ *      It implements the vector interface.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
 #include "merak.h"
 #include <math.h>
 
 
 
 
+        /* define the __merak_vector struct that was forward-declared in the
+         * merak/merak.h header file; this struct contains the following fields:
+         *   - x: the x coordinate
+         *   - y: the y coordinate */
 struct __merak_vector {
         sol_f32 x;
         sol_f32 y;
@@ -12,50 +45,56 @@ struct __merak_vector {
 
 
 
+        /* define the epsilon value used for comparing floating-point values */
 #define FLOAT_EPSILON (0.000001f)
 
 
 
 
-/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+        /* define the float_lt() utility function; this function returns true if
+         * @lhs < @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
 static sol_inline SOL_BOOL float_lt(sol_float lhs, sol_float rhs)
 {
         return (rhs - lhs) > ((fabs(lhs) < fabs(rhs)
                               ? fabs(rhs)
-                              : fabs(lhs)) * FLOAT_EPSILON)
-               ? SOL_BOOL_TRUE
-               : SOL_BOOL_FALSE;
+                              : fabs(lhs)) * FLOAT_EPSILON);
 }
 
 
 
 
-/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+        /* define the float_eq() utility function; this function returns true if
+         * @lhs == @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
 static sol_inline SOL_BOOL float_eq(sol_float lhs, sol_float rhs)
 {
         return fabs(lhs - rhs) <= ((fabs(lhs) > fabs(rhs)
                                    ? fabs(rhs)
-                                   : fabs(lhs)) * FLOAT_EPSILON)
-               ? SOL_BOOL_TRUE
-               : SOL_BOOL_FALSE;
+                                   : fabs(lhs)) * FLOAT_EPSILON);
 }
 
 
 
 
-/* https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison*/
+        /* define the float_gt() utility function; this function returns true if
+         * @lhs > @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
 static SOL_BOOL float_gt(sol_float lhs, sol_float rhs)
 {
         return (lhs - rhs) > ((fabs(lhs) < fabs(rhs)
                               ? fabs(rhs)
-                              : fabs(lhs)) * FLOAT_EPSILON)
-               ? SOL_BOOL_TRUE
-               : SOL_BOOL_FALSE;
+                              : fabs(lhs)) * FLOAT_EPSILON);
 }
 
 
 
 
+        /* implement the merak_vector_new() interface function; we defer the
+         * precondition check for @vec to merak_vector_new2() */
 extern sol_erno merak_vector_new(merak_vector **vec)
 {
         const sol_float def = (sol_float) 0.0;
@@ -73,6 +112,8 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_new2() interface function; we defer the
+         * precondition check for @vec to sol_ptr_new() */
 extern sol_erno merak_vector_new2(merak_vector **vec,
                                   const sol_float x,
                                   const sol_float y)
@@ -80,8 +121,6 @@ extern sol_erno merak_vector_new2(merak_vector **vec,
         auto merak_vector *hnd;
 
 SOL_TRY:
-        sol_assert (vec, SOL_ERNO_PTR);
-
         sol_try (sol_ptr_new((sol_ptr **) vec, sizeof (**vec)));
         hnd = *vec;
 
@@ -98,6 +137,8 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_copy() interface function; we defer the
+         * precondition check for @lhs to merak_vector_new2() */
 extern sol_erno merak_vector_copy(merak_vector **lhs, const merak_vector *rhs)
 {
 SOL_TRY:
@@ -117,6 +158,7 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_free() interface function */
 extern void merak_vector_free(merak_vector **vec)
 {
         sol_ptr_free((sol_ptr **) vec);
@@ -125,6 +167,7 @@ extern void merak_vector_free(merak_vector **vec)
 
 
 
+        /* implement the merak_vector_x() interface function */
 extern sol_erno merak_vector_x(const merak_vector *vec, sol_float *x)
 {
 SOL_TRY:
@@ -142,6 +185,7 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_y() interface function */
 extern sol_erno merak_vector_y(const merak_vector *vec, sol_float *y)
 {
 SOL_TRY:
@@ -159,6 +203,9 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_len() interface function; the length of a
+         * vector is calculated by deriving the square root of the sum of
+         * squares of its x and y components: (x^2 + y^2)^1/2 */
 extern sol_erno merak_vector_len(const merak_vector *vec, sol_float *len)
 {
 SOL_TRY:
@@ -177,6 +224,7 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_setx() interface function */
 extern sol_erno merak_vector_setx(merak_vector *vec, const sol_float x)
 {
 SOL_TRY:
@@ -194,6 +242,7 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_sety() interface function */
 extern sol_erno merak_vector_sety(merak_vector *vec, const sol_float y)
 {
 SOL_TRY:
@@ -211,6 +260,33 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_norm() interface function; we get the
+         * normal form of a vector by multiplying it with the inverse of its
+         * length; we need to ensure that the length of @vec is non-zero */
+extern sol_erno merak_vector_norm(merak_vector *vec)
+{
+        auto sol_float len;
+
+SOL_TRY:
+        sol_try (merak_vector_len(vec, &len));
+
+        if (sol_likely (!float_eq(len, (sol_float) 0.0)))
+                sol_try (merak_vector_mul(vec, (1.0 / len)));
+
+SOL_CATCH:
+        sol_log_erno(sol_erno_get());
+
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* implement the merak_vector_lt() interface function; a vector is
+         * considered to be less than another if the length of the former is
+         * less than that of the latter; we use the float_lt() utility function
+         * defined above to perform a safe comparison */
 extern sol_erno merak_vector_lt(const merak_vector *lhs,
                                 const merak_vector *rhs,
                                 SOL_BOOL *lt)
@@ -234,6 +310,10 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_eq() interface function; a vector is
+         * considered to be equal to another if the length of the former is
+         * equal to that of the latter; we use the float_eq() utility function
+         * defined above to perform a safe comparison */
 extern sol_erno merak_vector_eq(const merak_vector *lhs,
                                 const merak_vector *rhs,
                                 SOL_BOOL *eq)
@@ -257,6 +337,10 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_gt() interface function; a vector is
+         * considered to be greater than another if the length of the former is
+         * greater than that of the latter; we use the float_gt() utility
+         * function defined above to perform a safe comparison */
 extern sol_erno merak_vector_gt(const merak_vector *lhs,
                                 const merak_vector *rhs,
                                 SOL_BOOL *gt)
@@ -280,34 +364,15 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_add() interface function; we add two
+         * vectors by adding their individual components */
 extern sol_erno merak_vector_add(merak_vector *lhs, const merak_vector *rhs)
 {
 SOL_TRY:
-        sol_assert (rhs, SOL_ERNO_PTR);
+        sol_assert (lhs && rhs, SOL_ERNO_PTR);
 
-        sol_try (merak_vector_add2(lhs,
-                                   (sol_float) rhs->x,
-                                   (sol_float) rhs->y));
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-extern sol_erno merak_vector_add2(merak_vector *vec,
-                                  const sol_float x,
-                                  const sol_float y)
-{
-SOL_TRY:
-        sol_assert (vec, SOL_ERNO_PTR);
-
-        vec->x += (sol_f32) x;
-        vec->y += (sol_f32) y;
+        lhs->x += rhs->x;
+        lhs->y += rhs->y;
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
@@ -319,34 +384,15 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_sub() interface function; we subtract two
+         * vectors by subtracting their individual components */
 extern sol_erno merak_vector_sub(merak_vector *lhs, const merak_vector *rhs)
 {
 SOL_TRY:
-        sol_assert (rhs, SOL_ERNO_PTR);
+        sol_assert (lhs && rhs, SOL_ERNO_PTR);
 
-        sol_try (merak_vector_sub2(lhs,
-                                   (sol_float) rhs->x,
-                                   (sol_float) rhs->y));
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-extern sol_erno merak_vector_sub2(merak_vector *vec,
-                                  const sol_float x,
-                                  const sol_float y)
-{
-SOL_TRY:
-        sol_assert (vec, SOL_ERNO_PTR);
-
-        vec->x -= (sol_f32) x;
-        vec->y -= (sol_f32) y;
+        lhs->x -= rhs->x;
+        lhs->y -= rhs->y;
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
@@ -358,6 +404,9 @@ SOL_FINALLY:
 
 
 
+        /* implement the merak_vector_mul() interface function; we multiply a
+         * vector with a scalar by multiplying the individual components of the
+         * former with the latter */
 extern sol_erno merak_vector_mul(merak_vector *vec, const sol_float scalar)
 {
 SOL_TRY:
@@ -375,6 +424,10 @@ SOL_FINALLY:
 
 
 
+
+        /* implement the merak_vector_div() interface function; we divide a
+         * vector with a scalar by dividing the individual components of the
+         * former with the latter; we need to ensure that @scalar is non-zero */
 extern sol_erno merak_vector_div(merak_vector *vec, const sol_float scalar)
 {
 SOL_TRY:
@@ -394,20 +447,7 @@ SOL_FINALLY:
 
 
 
-extern sol_erno merak_vector_norm(merak_vector *vec)
-{
-        auto sol_float len;
-
-SOL_TRY:
-        sol_try (merak_vector_len(vec, &len));
-
-        if (sol_likely (!float_eq(len, (sol_float) 0.0)))
-                sol_try (merak_vector_mul(vec, (1.0 / len)));
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
+/******************************************************************************
+ *                                    EOF
+ ******************************************************************************/
 

--- a/src/typster.c
+++ b/src/typster.c
@@ -10,42 +10,17 @@ static typster_enemy *enemy = SOL_PTR_NULL;
 
 
 
-        /* handles the input for a frame */
-sol_erno frame_input(void)
+        /* updates the state of a frame */
+sol_erno frame_update(void)
 {
-        auto MERAK_EVENT_CODE code;
-
-SOL_TRY:
-        sol_try (merak_event_poll(&code));
-
-        while (code) {
-                switch (code) {
-                case MERAK_EVENT_CODE_QUIT:
-                        merak_screen_exit();
-                        merak_event_exit();
-                        merak_game_exit();
-                        break;
-
-                default:
-                        break;
-                }
-
-                sol_try (merak_event_poll(&code));
-        }
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-
+        return SOL_ERNO_NULL;
 }
 
 
 
 
-        /* updates the state of a frame */
-sol_erno frame_update(void)
+        /* renders a frame */
+sol_erno frame_render(void)
 {
         auto merak_shade shade;
 
@@ -55,22 +30,6 @@ SOL_TRY:
         shade.blue = 255;
         shade.alpha = 96;
         sol_try (merak_screen_clear(&shade));
-
-SOL_CATCH:
-        sol_log_erno(sol_erno_get());
-
-SOL_FINALLY:
-        return sol_erno_get();
-}
-
-
-
-
-        /* renders a frame */
-sol_erno frame_render(void)
-{
-SOL_TRY:
-        sol_assert (SOL_BOOL_TRUE, SOL_ERNO_STATE);
 
 SOL_CATCH:
         sol_log_erno(sol_erno_get());
@@ -95,12 +54,14 @@ SOL_TRY:
         res.width = 1280;
         res.height = 720;
 
-        sol_try (merak_game_init(&frame_input, &frame_update, &frame_render));
+        sol_try (merak_game_init(&frame_update, &frame_render));
         sol_try (merak_screen_init("Typster", &res, SOL_BOOL_TRUE));
         sol_try (merak_event_init());
+        sol_try (merak_arena_init());
+        sol_try (merak_keyboard_init());
 
         sol_try (typster_enemy_new(&enemy));
-        sol_try (merak_game_register((merak_entity *) enemy));
+        sol_try (merak_arena_push((merak_entity *) enemy));
 
         sol_try (merak_game_run());
 
@@ -112,6 +73,8 @@ SOL_FINALLY:
 
         merak_screen_exit();
         merak_event_exit();
+        merak_keyboard_exit();
+        merak_arena_exit();
         merak_game_exit();
 
         sol_log_close();


### PR DESCRIPTION
The keyboard manager interface has now been implemented. The keyboard
manager interface provides the following two enumerations:
  * `MERAK_KEYBOARD_KEY` to represent the keyboard USB HID scan codes
  * `MERAK_KEYBOARD_STATE` to represent the state of a keyboard key.

The following functions have also been implemented as part of the
keyboard manager interface:
  * `merak_keyoard_init()`
  * `merak_keyoard_exit()`
  * `merak_keyoard_scan()`
  * `merak_keyoard_update()`

Additionally, the game input handler delegate has been removed as it is
now redundant, and the `merak_event_update()` function now makes use of
the keyboard manager. An arena manager has also been implemented to take
care of managing the game entities, thereby simplifying the game
manager.

This pull request closes #13.